### PR TITLE
search speedup 

### DIFF
--- a/capella_console_client/config.py
+++ b/capella_console_client/config.py
@@ -1,6 +1,7 @@
-CONSOLE_API_URL = "https://api.capellaspace.com"  # PROD
+CONSOLE_API_URL = "https://api.capellaspace.com"
+API_GATEWAY = "https://0r1mdcwa5c.execute-api.us-west-2.amazonaws.com/prod"
 DEFAULT_TIMEOUT = 60
-DEFAULT_PAGE_SIZE = 500
+DEFAULT_PAGE_SIZE = 999
 DEFAULT_MAX_FEATURE_COUNT = 500
 
 

--- a/capella_console_client/hooks.py
+++ b/capella_console_client/hooks.py
@@ -24,6 +24,6 @@ def log_on_4xx_5xx(response):
 
 def retry_if_http_status_error(exception):
     """Return upon httpx.HTTPStatusError"""
-    if exception.code in NON_RETRYABLE_ERROR_CODES:
+    if getattr(exception, "code", None) in NON_RETRYABLE_ERROR_CODES:
         return False
     return isinstance(exception, CapellaConsoleClientError)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from capella_console_client import client as capella_client_module
-from capella_console_client.config import CONSOLE_API_URL
+from capella_console_client.config import CONSOLE_API_URL, API_GATEWAY
 from capella_console_client import CapellaConsoleClient
 from capella_console_client import client
 
@@ -168,7 +168,7 @@ def verbose_download_client(verbose_test_client, auth_httpx_mock):
 @pytest.fixture
 def verbose_download_multiple_client(verbose_test_client, auth_httpx_mock):
     auth_httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json=search_catalog_get_stac_ids(),
     )
     auth_httpx_mock.add_response(
@@ -192,6 +192,10 @@ def verbose_download_multiple_client(verbose_test_client, auth_httpx_mock):
 @pytest.fixture
 def single_page_search_client(verbose_test_client, auth_httpx_mock):
     auth_httpx_mock.add_response(
+        url=f"{API_GATEWAY}/search",
+        json=search_catalog_get_stac_ids(),
+    )
+    auth_httpx_mock.add_response(
         url=f"{CONSOLE_API_URL}/catalog/search",
         json=search_catalog_get_stac_ids(),
     )
@@ -201,7 +205,7 @@ def single_page_search_client(verbose_test_client, auth_httpx_mock):
 @pytest.fixture
 def multi_page_search_client(verbose_test_client, auth_httpx_mock):
     auth_httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json=search_catalog_get_stac_ids_multi_page(),
     )
     auth_httpx_mock.add_response(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from capella_console_client.config import CONSOLE_API_URL
+from capella_console_client.config import CONSOLE_API_URL, API_GATEWAY
 from capella_console_client import client as capella_client_module
 from capella_console_client.exceptions import (
     NoValidStacIdsError,
@@ -56,7 +56,7 @@ def test_list_active_orders(non_expired_order_mock):
 
 def test_review_order(order_client, httpx_mock):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": [{"id": "MOCK_STAC_ID", "collection": "capella-test"}]},
     )
     order_client.review_order(stac_ids=["MOCK_STAC_ID"])
@@ -64,7 +64,7 @@ def test_review_order(order_client, httpx_mock):
 
 def test_review_order_insufficient_funds(review_client_insufficient_funds, httpx_mock):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": [{"id": "MOCK_STAC_ID", "collection": "capella-test"}]},
     )
 
@@ -74,7 +74,7 @@ def test_review_order_insufficient_funds(review_client_insufficient_funds, httpx
 
 def test_review_order_no_match(order_client, httpx_mock):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": []},
     )
     with pytest.raises(NoValidStacIdsError):
@@ -85,7 +85,7 @@ def test_submit_order_not_previously_ordered_check_active_orders(
     order_client, httpx_mock
 ):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": [{"id": "MOCK_STAC_ID", "collection": "capella-test"}]},
     )
 
@@ -106,7 +106,7 @@ def test_submit_order_not_previously_ordered_no_check_active_orders(
     order_client, httpx_mock, assert_all_responses_were_requested
 ):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": [{"id": "MOCK_STAC_ID", "collection": "capella-test"}]},
     )
     order_id = order_client.submit_order(
@@ -138,7 +138,7 @@ def test_submit_order_previously_ordered(non_expired_order_mock, httpx_mock):
 
 def test_submit_order_invalid_stac_id(test_client, httpx_mock):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         method="POST",
         json={"features": []},
     )
@@ -150,7 +150,7 @@ def test_submit_order_invalid_stac_id(test_client, httpx_mock):
 def test_submit_order_rejected(order_client_unsuccessful, httpx_mock):
 
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         method="POST",
         json={
             "features": [
@@ -168,7 +168,7 @@ def test_submit_order_rejected(order_client_unsuccessful, httpx_mock):
 
 def test_submit_order_items(order_client, httpx_mock):
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={"features": [{"id": "MOCK_STAC_ID", "collection": "capella-test"}]},
     )
 
@@ -242,7 +242,7 @@ def test_get_stac_items_of_order(
     )
 
     httpx_mock.add_response(
-        url=f"{CONSOLE_API_URL}/catalog/search",
+        url=f"{API_GATEWAY}/search",
         json={
             "features": [{"id": "CAPELLA_C02_SM_SLC_HH_20201126192221_20201126192225"}]
         },

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 
 import pytest
+import httpx
+from pytest_httpx import HTTPXMock
 from unittest.mock import MagicMock
 
 from .test_data import get_search_test_cases, search_catalog_get_stac_ids
 from capella_console_client import client
+from capella_console_client import search
 from capella_console_client.validate import _validate_uuid
-from capella_console_client.search import _paginated_search
+from capella_console_client.search import _paginated_search, _page_search
 
 
 @pytest.mark.parametrize("search_args,expected", get_search_test_cases())
@@ -29,3 +32,26 @@ def test_paginated_search_single_page(single_page_search_client):
 def test_paginated_search_multi_page(multi_page_search_client):
     results = _paginated_search(multi_page_search_client._sesh, payload={"limit": 10})
     assert len(results) == 10
+
+
+@pytest.fixture
+def outdated_gateway_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        search,
+        "API_GATEWAY",
+        "https://phishphish.execute-api.us-west-2.amazonaws.com/prod",
+    )
+
+
+def test_single_page_search_fallback(
+    single_page_search_client, outdated_gateway_endpoint, auth_httpx_mock
+):
+    def raise_connect_error(request, extensions: dict):
+        raise httpx.ConnectError("host unknown", request=request)
+
+    auth_httpx_mock.add_callback(
+        raise_connect_error, url=f"{search.API_GATEWAY}/search"
+    )
+
+    with single_page_search_client._sesh:
+        _page_search(single_page_search_client._sesh, payload={"limit": 1})


### PR DESCRIPTION
by using API_GATEWAY directly (with fallback to /catalog/search)) 
adjusting pagesize to 999 for large queries 
rightsizing requested limit with logging