### PR TITLE
Update assets.py

### DIFF
--- a/capella_console_client/assets.py
+++ b/capella_console_client/assets.py
@@ -100,7 +100,7 @@ def _gather_download_requests(
 def _get_raster_href(assets_presigned: Dict[str, Any]) -> str:
     raster_asset = assets_presigned.get("HH")
     if raster_asset is None:
-        raster_asset = assets_presigned["VV"]
+        raster_asset = assets_presigned["analytic_product"]
 
     raster_asset_href: str = raster_asset["href"]
     return raster_asset_href


### PR DESCRIPTION
If the product to download is VS, there is an error in the function _get_raster_href from assets.py

![image](https://user-images.githubusercontent.com/80270168/199710528-4c039980-20c8-4ac1-844c-42f023efab69.png)

If the product is VS, there is no keyword VV. To solve this issue I ve changed keyword "VV" by "analytic_product" in function _get_raster_href. 

AFter that change i can get the VS product as expected:

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/80270168/199710983-93be1b49-fe4f-42c4-ba89-bc09b3431d52.png">
