### PR TITLE
trying to handle and refresh expired access token from vague 'Unauthorized' API response

### DIFF
--- a/capella_console_client/exceptions.py
+++ b/capella_console_client/exceptions.py
@@ -67,6 +67,8 @@ COLLECTION_ACCESS_DENIED_ERROR_CODE = "COLLECTION_ACCESS_DENIED"
 NOT_AUTHORIZED_ERROR_CODE = "NOT_AUTHORIZED"
 ORDER_VALIDATION_ERROR_CODE = "ORDER_VALIDATION_ERROR"
 
+UNAUTHORIZED_MESSAGE = "unauthorized"
+
 ERROR_CODES = {
     INVALID_TOKEN_ERROR_CODE: AuthenticationError,
     ORDER_EXPIRED_ERROR_CODE: OrderExpiredError,
@@ -106,6 +108,9 @@ def handle_error_response_and_raise(response):
         message = error
         code = DEFAULT_ERROR_CODE
         data = {}
+
+    if message is not None and message.lower() == UNAUTHORIZED_MESSAGE and code == DEFAULT_ERROR_CODE:
+        code = INVALID_TOKEN_ERROR_CODE
 
     # try to assign some more meaningful exception class by message
     if code == DEFAULT_ERROR_CODE and message:

--- a/capella_console_client/session.py
+++ b/capella_console_client/session.py
@@ -154,6 +154,7 @@ class CapellaConsoleSession(httpx.Client):
             # retry request
             orig_request = fct_args[0]
             orig_request.headers["authorization"] = self.headers["authorization"]
+            logger.info(f"retrying {fct_args[0]}")
             ret = super().send(*fct_args, **kwargs)
         return ret
 


### PR DESCRIPTION
```sh
2023-12-19 14:05:31,700 - 🛰️  Capella Space 🐐 - ERROR - Request: POST https://api.capellaspace.com/catalog/search - Status: 401 - Response: {'message': 'Unauthorized'}
2023-12-19 14:05:31,993 - 🛰️  Capella Space 🐐 - INFO - successfully refreshed access token
2023-12-19 14:05:31,993 - 🛰️  Capella Space 🐐 - INFO - retrying <Request('POST', 'https://api.capellaspace.com/catalog/search')>
```