### PR TITLE
Add ownership to STAC search

### DIFF
--- a/capella_console_client/client.py
+++ b/capella_console_client/client.py
@@ -851,7 +851,7 @@ class CapellaConsoleClient:
 
         filtering by ownership (optional):
          • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
-         
+
         supported operations:
          • eq: equality search
          • in: within group

--- a/capella_console_client/client.py
+++ b/capella_console_client/client.py
@@ -859,7 +859,7 @@ class CapellaConsoleClient:
 
         sorting:
          • sortby: List[str] - must be supported fields, e.g. ["+datetime"]
-         
+
         filtering by ownership (optional):
          • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
 

--- a/capella_console_client/client.py
+++ b/capella_console_client/client.py
@@ -848,8 +848,6 @@ class CapellaConsoleClient:
          • resolution_ground_range: float, Resolution ground range (m), e.g. 0.5
          • resolution_range: float, Resolution range (m), e.g. 0.5
          • squint_angle: float, Squint angle, e.g. 30.1
-
-        filtering by ownership (optional):
          • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
 
         supported operations:

--- a/capella_console_client/client.py
+++ b/capella_console_client/client.py
@@ -859,6 +859,9 @@ class CapellaConsoleClient:
 
         sorting:
          • sortby: List[str] - must be supported fields, e.g. ["+datetime"]
+         
+        filtering by ownership (optional):
+         • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
 
         Returns:
             List[Dict[str, Any]]: STAC items matched

--- a/capella_console_client/client.py
+++ b/capella_console_client/client.py
@@ -849,6 +849,9 @@ class CapellaConsoleClient:
          • resolution_range: float, Resolution range (m), e.g. 0.5
          • squint_angle: float, Squint angle, e.g. 30.1
 
+        filtering by ownership (optional):
+         • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
+         
         supported operations:
          • eq: equality search
          • in: within group
@@ -860,8 +863,6 @@ class CapellaConsoleClient:
         sorting:
          • sortby: List[str] - must be supported fields, e.g. ["+datetime"]
 
-        filtering by ownership (optional):
-         • ownership: str, one of "ownedByOrganization", "sharedWithOrganization", "availableForPurchase", "publiclyAvailable"
 
         Returns:
             List[Dict[str, Any]]: STAC items matched

--- a/capella_console_client/config.py
+++ b/capella_console_client/config.py
@@ -49,6 +49,13 @@ SUPPORTED_QUERY_FIELDS = {
     "epsg",
 }
 
+SUPPORTED_OWNERSHIP_OPTIONS = {
+  "ownedByOrganization",
+  "sharedWithOrganization",
+  "availableForPurchase",
+  "publiclyAvailable",
+}
+
 ALL_SUPPORTED_FIELDS = SUPPORTED_SEARCH_FIELDS | SUPPORTED_QUERY_FIELDS
 
 ALL_SUPPORTED_SORTBY = ALL_SUPPORTED_FIELDS | {"id"}

--- a/capella_console_client/config.py
+++ b/capella_console_client/config.py
@@ -50,10 +50,10 @@ SUPPORTED_QUERY_FIELDS = {
 }
 
 SUPPORTED_OWNERSHIP_OPTIONS = {
-  "ownedByOrganization",
-  "sharedWithOrganization",
-  "availableForPurchase",
-  "publiclyAvailable",
+    "ownedByOrganization",
+    "sharedWithOrganization",
+    "availableForPurchase",
+    "publiclyAvailable",
 }
 
 ALL_SUPPORTED_FIELDS = SUPPORTED_SEARCH_FIELDS | SUPPORTED_QUERY_FIELDS

--- a/capella_console_client/config.py
+++ b/capella_console_client/config.py
@@ -49,13 +49,6 @@ SUPPORTED_QUERY_FIELDS = {
     "epsg",
 }
 
-SUPPORTED_OWNERSHIP_OPTIONS = {
-    "ownedByOrganization",
-    "sharedWithOrganization",
-    "availableForPurchase",
-    "publiclyAvailable",
-}
-
 ALL_SUPPORTED_FIELDS = SUPPORTED_SEARCH_FIELDS | SUPPORTED_QUERY_FIELDS
 
 ALL_SUPPORTED_SORTBY = ALL_SUPPORTED_FIELDS | {"id"}

--- a/capella_console_client/enumerations.py
+++ b/capella_console_client/enumerations.py
@@ -126,7 +126,11 @@ class LocalTimeOption(str, BaseEnum):
 
 
 class OwnershipOption(str, BaseEnum):
-    owned_by_organization = "ownedByOrganization"
-    publicly_available = "publiclyAvailable"
-    shared_with_organization = "sharedWithOrganization"
-    available_for_purchase = "availableForPurchase"
+    ORG = "ownedByOrganization"
+    PUBLIC = "publiclyAvailable"
+    SHARED = "sharedWithOrganization"
+    PURCHASABLE = "availableForPurchase"
+
+    @classmethod
+    def is_valid(cls, option_str: str) -> bool:
+        return option_str in list(cls)

--- a/capella_console_client/enumerations.py
+++ b/capella_console_client/enumerations.py
@@ -123,3 +123,9 @@ class LocalTimeOption(str, BaseEnum):
     day = "day"
     night = "night"
     anytime = "anytime"
+    
+class OwnershipOption(str, BaseEnum):
+    owned_by_organization = "ownedByOrganization"
+    publicly_available = "publiclyAvailable"
+    shared_with_organization = "sharedWithOrganization"
+    available_for_purchase = "availableForPurchase"

--- a/capella_console_client/enumerations.py
+++ b/capella_console_client/enumerations.py
@@ -123,7 +123,8 @@ class LocalTimeOption(str, BaseEnum):
     day = "day"
     night = "night"
     anytime = "anytime"
-    
+
+
 class OwnershipOption(str, BaseEnum):
     owned_by_organization = "ownedByOrganization"
     publicly_available = "publiclyAvailable"

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -22,6 +22,7 @@ from capella_console_client.config import (
     ALL_SUPPORTED_GROUPBY_FIELDS,
     ROOT_LEVEL_GROUPBY_FIELDS,
     UNKNOWN_GROUPBY_FIELD,
+    SUPPORTED_OWNERSHIP_OPTIONS,
 )
 
 
@@ -149,6 +150,10 @@ class StacSearch:
         if sortby:
             self.payload["sortby"] = self._get_sort_payload(sortby)
 
+        ownership = self._get_ownership_payload(cur_kwargs)
+        if ownership:
+            self.payload["ownership"] = ownership
+
         query_payload = self._get_query_payload(cur_kwargs)
         if query_payload:
             self.payload["query"] = dict(query_payload)
@@ -186,6 +191,17 @@ class StacSearch:
 
         return query_payload
 
+    def _get_ownership_payload(self, kwargs) -> Optional[str]:
+      ownership = kwargs.pop("ownership", None)
+      if not ownership:
+          return
+
+      if ownership not in SUPPORTED_OWNERSHIP_OPTIONS:
+          logger.warning(f"ownership option {ownership} not supported ... omitting")
+          return
+      
+      return ownership
+      
     def _split_op(self, cur_field: str) -> Tuple[str, str]:
         parts = cur_field.split("__")
         if len(parts) == 2:

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -22,8 +22,8 @@ from capella_console_client.config import (
     ALL_SUPPORTED_GROUPBY_FIELDS,
     ROOT_LEVEL_GROUPBY_FIELDS,
     UNKNOWN_GROUPBY_FIELD,
-    SUPPORTED_OWNERSHIP_OPTIONS,
 )
+from capella_console_client.enumerations import OwnershipOption
 
 
 @dataclass
@@ -70,7 +70,7 @@ class SearchResult:
             message = f"found {len_results} STAC item{multiple_suffix}"
         logger.info(message)
 
-    # backwards compability
+    # backwards compatibility
     def __getitem__(self, key):
         return self._features.__getitem__(key)
 
@@ -150,9 +150,10 @@ class StacSearch:
         if sortby:
             self.payload["sortby"] = self._get_sort_payload(sortby)
 
-        ownership = self._get_ownership_payload(cur_kwargs)
-        if ownership:
-            self.payload["ownership"] = ownership
+        input_ownership = kwargs.pop("ownership", None)
+        ownership_payload = self._get_ownership_payload(input_ownership)
+        if ownership_payload:
+            self.payload["ownership"] = ownership_payload
 
         query_payload = self._get_query_payload(cur_kwargs)
         if query_payload:
@@ -191,12 +192,8 @@ class StacSearch:
 
         return query_payload
 
-    def _get_ownership_payload(self, kwargs) -> Optional[str]:
-        ownership = kwargs.pop("ownership", None)
-        if not ownership:
-            return None
-
-        if ownership not in SUPPORTED_OWNERSHIP_OPTIONS:
+    def _get_ownership_payload(self, ownership) -> Optional[str]:
+        if ownership not in list(OwnershipOption):
             logger.warning(f"ownership option {ownership} not supported ... omitting")
             return None
 

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -150,10 +150,9 @@ class StacSearch:
         if sortby:
             self.payload["sortby"] = self._get_sort_payload(sortby)
 
-        input_ownership = kwargs.pop("ownership", None)
-        ownership_payload = self._get_ownership_payload(input_ownership)
-        if ownership_payload:
-            self.payload["ownership"] = ownership_payload
+        ownership_option = cur_kwargs.pop("ownership", None)
+        if OwnershipOption.is_valid(ownership_option):
+            self.payload["ownership"] = ownership_option
 
         query_payload = self._get_query_payload(cur_kwargs)
         if query_payload:

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -194,11 +194,11 @@ class StacSearch:
     def _get_ownership_payload(self, kwargs) -> Optional[str]:
         ownership = kwargs.pop("ownership", None)
         if not ownership:
-            return
+            return None
 
         if ownership not in SUPPORTED_OWNERSHIP_OPTIONS:
             logger.warning(f"ownership option {ownership} not supported ... omitting")
-            return
+            return None
 
         return ownership
 

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -192,16 +192,16 @@ class StacSearch:
         return query_payload
 
     def _get_ownership_payload(self, kwargs) -> Optional[str]:
-      ownership = kwargs.pop("ownership", None)
-      if not ownership:
-          return
+        ownership = kwargs.pop("ownership", None)
+        if not ownership:
+            return
 
-      if ownership not in SUPPORTED_OWNERSHIP_OPTIONS:
-          logger.warning(f"ownership option {ownership} not supported ... omitting")
-          return
-      
-      return ownership
-      
+        if ownership not in SUPPORTED_OWNERSHIP_OPTIONS:
+            logger.warning(f"ownership option {ownership} not supported ... omitting")
+            return
+
+        return ownership
+
     def _split_op(self, cur_field: str) -> Tuple[str, str]:
         parts = cur_field.split("__")
         if len(parts) == 2:

--- a/capella_console_client/search.py
+++ b/capella_console_client/search.py
@@ -191,13 +191,6 @@ class StacSearch:
 
         return query_payload
 
-    def _get_ownership_payload(self, ownership) -> Optional[str]:
-        if ownership not in list(OwnershipOption):
-            logger.warning(f"ownership option {ownership} not supported ... omitting")
-            return None
-
-        return ownership
-
     def _split_op(self, cur_field: str) -> Tuple[str, str]:
         parts = cur_field.split("__")
         if len(parts) == 2:

--- a/docs/pages/example_usage.rst
+++ b/docs/pages/example_usage.rst
@@ -349,7 +349,7 @@ advanced search
 
     # use ownership filters
 
-    ownedGEOItems = client.search(
+    owned_geo_items = client.search(
         product_type="GEO",
         ownership="ownedByOrganization"
     )

--- a/docs/pages/example_usage.rst
+++ b/docs/pages/example_usage.rst
@@ -261,7 +261,7 @@ search fields
     * - ``product_type``
       - | product type str, one of
         | ``"SLC"``, ``"GEO"``, ``"GEC"``, ``"SICD"``, ``"SIDD"``, ``"CPHD"``
-        | ``"VS"``, ``"ACD"```
+        | ``"VS"``, ``"ACD"``
       - ``str``
       - ``"SLC"``
     * - ``resolution_azimuth``
@@ -280,6 +280,10 @@ search fields
       - squint angle
       - ``float``
       - ``30.1``
+    * - ``ownership``
+      - one of ``"ownedByOrganization"``, ``"sharedWithOrganization"``, ``"availableForPurchase"``, ``"publiclyAvailable"``
+      - ``str``
+      - ``"ownedByOrganization"``
 
 
 advanced search

--- a/docs/pages/example_usage.rst
+++ b/docs/pages/example_usage.rst
@@ -347,6 +347,12 @@ advanced search
         epsg=32648,
     )
 
+    # use ownership filters
+
+    ownedGEOItems = client.search(
+        product_type="GEO",
+        ownership="ownedByOrganization"
+    )
 
     # take it to the max - get GEO spotlight items over SF downtown with many filters sorted by datetime
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -651,6 +651,16 @@ def get_search_test_cases():
             },
             id="multiSortbyOmits",
         ),
+        pytest.param(
+            dict(ownership="invalidOwnershipOption"),
+            {"limit": CATALOG_DEFAULT_LIMIT},
+            id="filter_invalid_ownership",
+        ),
+        pytest.param(
+            dict(ownership="ownedByOrganization"),
+            {"limit": CATALOG_DEFAULT_LIMIT, "ownership": "ownedByOrganization"},
+            id="filter_valid_ownership",
+        ),
     ]
 
 


### PR DESCRIPTION
Recognizes an `ownership` option within the following values:

-  'ownedByOrganization'
-  'sharedWithOrganization'
-  'availableForPurchase'
-  'publiclyAvailable'

Docs are included.

# Example

```
stac_items = client.search(
    instrument_mode="spotlight",
    product_type__in=["SLC", "GEO"],
    collections=["capella-open-data"],
    ownership="ownedByOrganization",
    limit=2
)
```

# Invalid options

Will display the following warning:

```
- 🛰️  Capella Space 🐐 - WARNING - ownership option someNotSupportedOption not supported ... omitting
```